### PR TITLE
added support for restricting device list access to certain tenants

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
 # iot-device-mgmt
 
 Device management service
+
+# Security
+
+## Authorization
+
+Authorization is handled via OIDC access tokens that are delegated to [Open Policy Agent](https://www.openpolicyagent.org) for validation and decoding. This service does not impose any restrictions on the structure of a token's claims, allowing freedom for policy writers to integrate with existing organisational policies more easily.
+
+The only requirement is that the policy evaluation result is an object that contains a list of the tenants that the client is allowed to access. This list can be fetched from an arbitrary claim in the access token or created in the policy file based on other properties such as groups or subject identity (sub).
+
+A [basic policy file](./assets/config/authz.rego) is included in the built image by default, but is expected to be replaced with an organisational specific policy at the time of deployment.

--- a/assets/config/authz.rego
+++ b/assets/config/authz.rego
@@ -1,13 +1,21 @@
+#
+# Use https://play.openpolicyagent.org for easier editing/validation of this policy file
+#
+
 package example.authz
 
 default allow := false
 
-allow {
+allow = response {
     is_valid_token
 
     input.method == "GET"
     pathstart := array.slice(input.path, 0, 3)
     pathstart == ["api", "v0", "devices"]
+
+    response := {
+        "tenants": token.payload.tenants
+    }
 }
 
 issuers := {"https://iam.diwise.io/realms/diwise-test"}
@@ -36,5 +44,5 @@ is_valid_token {
 }
 
 token := {"payload": payload} {
-    [header, payload, signature] := io.jwt.decode(input.token)
+    [_, payload, _] := io.jwt.decode(input.token)
 }

--- a/internal/pkg/application/application.go
+++ b/internal/pkg/application/application.go
@@ -20,7 +20,7 @@ type DeviceManagement interface {
 	UpdateDevice(ctx context.Context, deviceID string, fields map[string]interface{}) (Device, error)
 	CreateDevice(context.Context, Device) error
 	GetDeviceFromEUI(context.Context, string) (Device, error)
-	ListAllDevices(context.Context) ([]Device, error)
+	ListAllDevices(context.Context, []string) ([]Device, error)
 	UpdateLastObservedOnDevice(deviceID string, timestamp time.Time) error
 	ListEnvironments(context.Context) ([]Environment, error)
 	NotifyStatus(ctx context.Context, message StatusMessage) error
@@ -64,7 +64,8 @@ func (a *app) GetDeviceFromEUI(ctx context.Context, devEUI string) (Device, erro
 	return MapToModel(device), nil
 }
 
-func (a *app) ListAllDevices(ctx context.Context) ([]Device, error) {
+func (a *app) ListAllDevices(ctx context.Context, allowedTenants []string) ([]Device, error) {
+	// TODO: Pass allowedTenants to GetAll when we have merged our branches
 	devices, err := a.db.GetAll()
 	if err != nil {
 		return nil, err

--- a/internal/pkg/application/application.go
+++ b/internal/pkg/application/application.go
@@ -65,8 +65,8 @@ func (a *app) GetDeviceFromEUI(ctx context.Context, devEUI string) (Device, erro
 }
 
 func (a *app) ListAllDevices(ctx context.Context, allowedTenants []string) ([]Device, error) {
-	// TODO: Pass allowedTenants to GetAll when we have merged our branches
-	devices, err := a.db.GetAll()
+
+	devices, err := a.db.GetAll(allowedTenants)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/application/application_mock.go
+++ b/internal/pkg/application/application_mock.go
@@ -28,7 +28,7 @@ var _ DeviceManagement = &DeviceManagementMock{}
 // 			GetDeviceFromEUIFunc: func(contextMoqParam context.Context, s string) (Device, error) {
 // 				panic("mock out the GetDeviceFromEUI method")
 // 			},
-// 			ListAllDevicesFunc: func(contextMoqParam context.Context) ([]Device, error) {
+// 			ListAllDevicesFunc: func(contextMoqParam context.Context, strings []string) ([]Device, error) {
 // 				panic("mock out the ListAllDevices method")
 // 			},
 // 			ListEnvironmentsFunc: func(contextMoqParam context.Context) ([]Environment, error) {
@@ -60,7 +60,7 @@ type DeviceManagementMock struct {
 	GetDeviceFromEUIFunc func(contextMoqParam context.Context, s string) (Device, error)
 
 	// ListAllDevicesFunc mocks the ListAllDevices method.
-	ListAllDevicesFunc func(contextMoqParam context.Context) ([]Device, error)
+	ListAllDevicesFunc func(contextMoqParam context.Context, strings []string) ([]Device, error)
 
 	// ListEnvironmentsFunc mocks the ListEnvironments method.
 	ListEnvironmentsFunc func(contextMoqParam context.Context) ([]Environment, error)
@@ -101,6 +101,8 @@ type DeviceManagementMock struct {
 		ListAllDevices []struct {
 			// ContextMoqParam is the contextMoqParam argument value.
 			ContextMoqParam context.Context
+			// Strings is the strings argument value.
+			Strings []string
 		}
 		// ListEnvironments holds details about calls to the ListEnvironments method.
 		ListEnvironments []struct {
@@ -247,19 +249,21 @@ func (mock *DeviceManagementMock) GetDeviceFromEUICalls() []struct {
 }
 
 // ListAllDevices calls ListAllDevicesFunc.
-func (mock *DeviceManagementMock) ListAllDevices(contextMoqParam context.Context) ([]Device, error) {
+func (mock *DeviceManagementMock) ListAllDevices(contextMoqParam context.Context, strings []string) ([]Device, error) {
 	if mock.ListAllDevicesFunc == nil {
 		panic("DeviceManagementMock.ListAllDevicesFunc: method is nil but DeviceManagement.ListAllDevices was just called")
 	}
 	callInfo := struct {
 		ContextMoqParam context.Context
+		Strings         []string
 	}{
 		ContextMoqParam: contextMoqParam,
+		Strings:         strings,
 	}
 	mock.lockListAllDevices.Lock()
 	mock.calls.ListAllDevices = append(mock.calls.ListAllDevices, callInfo)
 	mock.lockListAllDevices.Unlock()
-	return mock.ListAllDevicesFunc(contextMoqParam)
+	return mock.ListAllDevicesFunc(contextMoqParam, strings)
 }
 
 // ListAllDevicesCalls gets all the calls that were made to ListAllDevices.
@@ -267,9 +271,11 @@ func (mock *DeviceManagementMock) ListAllDevices(contextMoqParam context.Context
 //     len(mockedDeviceManagement.ListAllDevicesCalls())
 func (mock *DeviceManagementMock) ListAllDevicesCalls() []struct {
 	ContextMoqParam context.Context
+	Strings         []string
 } {
 	var calls []struct {
 		ContextMoqParam context.Context
+		Strings         []string
 	}
 	mock.lockListAllDevices.RLock()
 	calls = mock.calls.ListAllDevices

--- a/internal/pkg/infrastructure/repositories/database/database.go
+++ b/internal/pkg/infrastructure/repositories/database/database.go
@@ -219,22 +219,22 @@ func (s store) UpdateLastObservedOnDevice(deviceID string, timestamp time.Time) 
 	return result.Error
 }
 
-func (s store) getTenantByName(tenantName string) (Tenant, error) {
+func (s store) getTenantByName(tenantName string) (*Tenant, error) {
 	var tenant Tenant
 
 	err := s.db.First(&tenant, "name = ?", tenantName).Error
 	if err != nil {
-		return Tenant{}, err
+		return nil, err
 	}
 
-	return tenant, nil
+	return &tenant, nil
 }
 
-func (s store) GetAll(tenants []string) ([]Device, error) {
+func (s store) GetAll(tenantNames []string) ([]Device, error) {
 	var deviceList []Device
 
-	for _, t := range tenants {
-		tenant, err := s.getTenantByName(t)
+	for _, name := range tenantNames {
+		tenant, err := s.getTenantByName(name)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/pkg/infrastructure/repositories/database/database.go
+++ b/internal/pkg/infrastructure/repositories/database/database.go
@@ -222,7 +222,7 @@ func (s store) UpdateLastObservedOnDevice(deviceID string, timestamp time.Time) 
 func (s store) getTenantByName(tenantName string) (Tenant, error) {
 	var tenant Tenant
 
-	err := s.db.Debug().First(&tenant, "name = ?", tenantName).Error
+	err := s.db.First(&tenant, "name = ?", tenantName).Error
 	if err != nil {
 		return Tenant{}, err
 	}
@@ -241,7 +241,7 @@ func (s store) GetAll(tenants []string) ([]Device, error) {
 
 		var devices []Device
 
-		err = s.db.Debug().Preload("Types").Preload("Environment").Preload("Tenant").Find(&devices, "tenant_id = ?", tenant.ID).Error
+		err = s.db.Preload("Types").Preload("Environment").Preload("Tenant").Find(&devices, "tenant_id = ?", tenant.ID).Error
 		if err != nil {
 			return nil, err
 		}

--- a/internal/pkg/infrastructure/repositories/database/database_mock.go
+++ b/internal/pkg/infrastructure/repositories/database/database_mock.go
@@ -15,46 +15,46 @@ var _ Datastore = &DatastoreMock{}
 
 // DatastoreMock is a mock implementation of Datastore.
 //
-//	func TestSomethingThatUsesDatastore(t *testing.T) {
+// 	func TestSomethingThatUsesDatastore(t *testing.T) {
 //
-//		// make and configure a mocked Datastore
-//		mockedDatastore := &DatastoreMock{
-//			CreateDeviceFunc: func(devEUI string, deviceId string, name string, description string, environment string, sensorType string, tenant string, latitude float64, longitude float64, types []string, active bool) (Device, error) {
-//				panic("mock out the CreateDevice method")
-//			},
-//			GetAllFunc: func() ([]Device, error) {
-//				panic("mock out the GetAll method")
-//			},
-//			GetDeviceFromDevEUIFunc: func(eui string) (Device, error) {
-//				panic("mock out the GetDeviceFromDevEUI method")
-//			},
-//			GetDeviceFromIDFunc: func(deviceID string) (Device, error) {
-//				panic("mock out the GetDeviceFromID method")
-//			},
-//			ListEnvironmentsFunc: func() ([]Environment, error) {
-//				panic("mock out the ListEnvironments method")
-//			},
-//			SeedFunc: func(r io.Reader) error {
-//				panic("mock out the Seed method")
-//			},
-//			UpdateDeviceFunc: func(deviceID string, fields map[string]interface{}) (Device, error) {
-//				panic("mock out the UpdateDevice method")
-//			},
-//			UpdateLastObservedOnDeviceFunc: func(deviceID string, timestamp time.Time) error {
-//				panic("mock out the UpdateLastObservedOnDevice method")
-//			},
-//		}
+// 		// make and configure a mocked Datastore
+// 		mockedDatastore := &DatastoreMock{
+// 			CreateDeviceFunc: func(devEUI string, deviceId string, name string, description string, environment string, sensorType string, tenant string, latitude float64, longitude float64, types []string, active bool) (Device, error) {
+// 				panic("mock out the CreateDevice method")
+// 			},
+// 			GetAllFunc: func(tenants []string) ([]Device, error) {
+// 				panic("mock out the GetAll method")
+// 			},
+// 			GetDeviceFromDevEUIFunc: func(eui string) (Device, error) {
+// 				panic("mock out the GetDeviceFromDevEUI method")
+// 			},
+// 			GetDeviceFromIDFunc: func(deviceID string) (Device, error) {
+// 				panic("mock out the GetDeviceFromID method")
+// 			},
+// 			ListEnvironmentsFunc: func() ([]Environment, error) {
+// 				panic("mock out the ListEnvironments method")
+// 			},
+// 			SeedFunc: func(r io.Reader) error {
+// 				panic("mock out the Seed method")
+// 			},
+// 			UpdateDeviceFunc: func(deviceID string, fields map[string]interface{}) (Device, error) {
+// 				panic("mock out the UpdateDevice method")
+// 			},
+// 			UpdateLastObservedOnDeviceFunc: func(deviceID string, timestamp time.Time) error {
+// 				panic("mock out the UpdateLastObservedOnDevice method")
+// 			},
+// 		}
 //
-//		// use mockedDatastore in code that requires Datastore
-//		// and then make assertions.
+// 		// use mockedDatastore in code that requires Datastore
+// 		// and then make assertions.
 //
-//	}
+// 	}
 type DatastoreMock struct {
 	// CreateDeviceFunc mocks the CreateDevice method.
 	CreateDeviceFunc func(devEUI string, deviceId string, name string, description string, environment string, sensorType string, tenant string, latitude float64, longitude float64, types []string, active bool) (Device, error)
 
 	// GetAllFunc mocks the GetAll method.
-	GetAllFunc func() ([]Device, error)
+	GetAllFunc func(tenants []string) ([]Device, error)
 
 	// GetDeviceFromDevEUIFunc mocks the GetDeviceFromDevEUI method.
 	GetDeviceFromDevEUIFunc func(eui string) (Device, error)
@@ -103,6 +103,8 @@ type DatastoreMock struct {
 		}
 		// GetAll holds details about calls to the GetAll method.
 		GetAll []struct {
+			// Tenants is the tenants argument value.
+			Tenants []string
 		}
 		// GetDeviceFromDevEUI holds details about calls to the GetDeviceFromDevEUI method.
 		GetDeviceFromDevEUI []struct {
@@ -185,8 +187,7 @@ func (mock *DatastoreMock) CreateDevice(devEUI string, deviceId string, name str
 
 // CreateDeviceCalls gets all the calls that were made to CreateDevice.
 // Check the length with:
-//
-//	len(mockedDatastore.CreateDeviceCalls())
+//     len(mockedDatastore.CreateDeviceCalls())
 func (mock *DatastoreMock) CreateDeviceCalls() []struct {
 	DevEUI      string
 	DeviceId    string
@@ -220,25 +221,29 @@ func (mock *DatastoreMock) CreateDeviceCalls() []struct {
 }
 
 // GetAll calls GetAllFunc.
-func (mock *DatastoreMock) GetAll() ([]Device, error) {
+func (mock *DatastoreMock) GetAll(tenants []string) ([]Device, error) {
 	if mock.GetAllFunc == nil {
 		panic("DatastoreMock.GetAllFunc: method is nil but Datastore.GetAll was just called")
 	}
 	callInfo := struct {
-	}{}
+		Tenants []string
+	}{
+		Tenants: tenants,
+	}
 	mock.lockGetAll.Lock()
 	mock.calls.GetAll = append(mock.calls.GetAll, callInfo)
 	mock.lockGetAll.Unlock()
-	return mock.GetAllFunc()
+	return mock.GetAllFunc(tenants)
 }
 
 // GetAllCalls gets all the calls that were made to GetAll.
 // Check the length with:
-//
-//	len(mockedDatastore.GetAllCalls())
+//     len(mockedDatastore.GetAllCalls())
 func (mock *DatastoreMock) GetAllCalls() []struct {
+	Tenants []string
 } {
 	var calls []struct {
+		Tenants []string
 	}
 	mock.lockGetAll.RLock()
 	calls = mock.calls.GetAll
@@ -264,8 +269,7 @@ func (mock *DatastoreMock) GetDeviceFromDevEUI(eui string) (Device, error) {
 
 // GetDeviceFromDevEUICalls gets all the calls that were made to GetDeviceFromDevEUI.
 // Check the length with:
-//
-//	len(mockedDatastore.GetDeviceFromDevEUICalls())
+//     len(mockedDatastore.GetDeviceFromDevEUICalls())
 func (mock *DatastoreMock) GetDeviceFromDevEUICalls() []struct {
 	Eui string
 } {
@@ -296,8 +300,7 @@ func (mock *DatastoreMock) GetDeviceFromID(deviceID string) (Device, error) {
 
 // GetDeviceFromIDCalls gets all the calls that were made to GetDeviceFromID.
 // Check the length with:
-//
-//	len(mockedDatastore.GetDeviceFromIDCalls())
+//     len(mockedDatastore.GetDeviceFromIDCalls())
 func (mock *DatastoreMock) GetDeviceFromIDCalls() []struct {
 	DeviceID string
 } {
@@ -325,8 +328,7 @@ func (mock *DatastoreMock) ListEnvironments() ([]Environment, error) {
 
 // ListEnvironmentsCalls gets all the calls that were made to ListEnvironments.
 // Check the length with:
-//
-//	len(mockedDatastore.ListEnvironmentsCalls())
+//     len(mockedDatastore.ListEnvironmentsCalls())
 func (mock *DatastoreMock) ListEnvironmentsCalls() []struct {
 } {
 	var calls []struct {
@@ -355,8 +357,7 @@ func (mock *DatastoreMock) Seed(r io.Reader) error {
 
 // SeedCalls gets all the calls that were made to Seed.
 // Check the length with:
-//
-//	len(mockedDatastore.SeedCalls())
+//     len(mockedDatastore.SeedCalls())
 func (mock *DatastoreMock) SeedCalls() []struct {
 	R io.Reader
 } {
@@ -389,8 +390,7 @@ func (mock *DatastoreMock) UpdateDevice(deviceID string, fields map[string]inter
 
 // UpdateDeviceCalls gets all the calls that were made to UpdateDevice.
 // Check the length with:
-//
-//	len(mockedDatastore.UpdateDeviceCalls())
+//     len(mockedDatastore.UpdateDeviceCalls())
 func (mock *DatastoreMock) UpdateDeviceCalls() []struct {
 	DeviceID string
 	Fields   map[string]interface{}
@@ -425,8 +425,7 @@ func (mock *DatastoreMock) UpdateLastObservedOnDevice(deviceID string, timestamp
 
 // UpdateLastObservedOnDeviceCalls gets all the calls that were made to UpdateLastObservedOnDevice.
 // Check the length with:
-//
-//	len(mockedDatastore.UpdateLastObservedOnDeviceCalls())
+//     len(mockedDatastore.UpdateLastObservedOnDeviceCalls())
 func (mock *DatastoreMock) UpdateLastObservedOnDeviceCalls() []struct {
 	DeviceID  string
 	Timestamp time.Time

--- a/internal/pkg/infrastructure/repositories/database/database_test.go
+++ b/internal/pkg/infrastructure/repositories/database/database_test.go
@@ -1,0 +1,40 @@
+package database
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/matryer/is"
+	"github.com/rs/zerolog"
+)
+
+const devices string = `devEUI;internalID;lat;lon;where;types;sensorType;name;description;active;tenant
+a81758fffe06bfa3;intern-a81758fffe06bfa3;62.39160;17.30723;water;urn:oma:lwm2m:ext:3303,urn:oma:lwm2m:ext:3302,urn:oma:lwm2m:ext:3301;Elsys_Codec;name-a81758fffe06bfa3;desc-a81758fffe06bfa3;true;default
+a81758fffe05e6fb;intern-a81758fffe05e6fb;62.39160;17.30723;;urn:oma:lwm2m:ext:3428;Elsys_Codec;name-a81758fffe06bfa3;desc-a81758fffe06bfa3;true;notdefault
+`
+
+func TestThatGetAllRetrievesByTenantNames(t *testing.T) {
+	testData := bytes.NewBuffer([]byte(devices))
+	is, db := testSetup(t, testData)
+
+	devs, err := db.GetAll([]string{"default"})
+	is.NoErr(err)
+	is.Equal(len(devs), 1)
+
+	devs, err = db.GetAll([]string{"default", "notdefault"})
+	is.NoErr(err)
+	is.Equal(len(devs), 2)
+}
+
+func testSetup(t *testing.T, testData io.Reader) (*is.I, Datastore) {
+	is := is.New(t)
+	log := zerolog.Logger{}
+	db, err := NewDatabaseConnection(NewSQLiteConnector(log))
+	is.NoErr(err)
+
+	db.Seed(testData)
+	is.NoErr(err)
+
+	return is, db
+}


### PR DESCRIPTION
* allowed tenants are returned from opa policy and can either be fetched from JWT or be decided in the policy file